### PR TITLE
Pass in browsers options to pixrem

### DIFF
--- a/src/__tests__/option.browsers.js
+++ b/src/__tests__/option.browsers.js
@@ -40,7 +40,7 @@ tape("cssnext browsers option", function(t) {
   t.end()
 })
 
-tape("cssnext browsers option propagation", function(t) {
+tape("cssnext browsers option propagation to autoprefixer", function(t) {
   const input = "body{transition: 1s}"
   const output = "body{-webkit-transition: 1s;transition: 1s}"
 
@@ -56,6 +56,20 @@ tape("cssnext browsers option propagation", function(t) {
     cssnext({ browsers: "Safari 6.1" }).process(input).css,
     input,
     "should propagate browsers option to autoprefixer"
+  )
+
+  t.end()
+})
+
+tape("cssnext browsers option propagation to pixrem", function(t) {
+  const input = "body{font-size: 1rem}"
+  const output = "body{font-size: 16px;font-size: 1rem}"
+
+  // IE 8 needs rem fallback
+  t.equal(
+    cssnext({ browsers: "ie 8" }).process(input).css,
+    output,
+    "should propagate browsers option to pixrem"
   )
 
   t.end()

--- a/src/index.js
+++ b/src/index.js
@@ -14,33 +14,25 @@ const plugin = postcss.plugin("postcss-cssnext", (options) => {
 
   const features = options.features
 
-  // propagate browsers option to autoprefixer
-  if (features.autoprefixer !== false) {
-    features.autoprefixer = {
-      browsers: (
-        features.autoprefixer && features.autoprefixer.browsers
-          ? features.autoprefixer.browsers
-          : options.browsers
-      ),
-      ...(features.autoprefixer || {}),
-    }
+  // propagate browsers option to plugins that supports it
+  "autoprefixer pixrem".split(/\s/).forEach(name => {
+    const feature = features[name]
 
-    // autoprefixer doesn't like an "undefined" value. Related to coffee ?
-    if (features.autoprefixer.browsers === undefined) {
-      delete features.autoprefixer.browsers
+    if (feature !== false) {
+      features[name] = {
+        browsers: (
+          feature && feature.browsers
+            ? feature.browsers
+            : options.browsers
+        ),
+        ...(feature || {}),
+      }
     }
-  }
+  })
 
-  // propagate browsers option to pixrem
-  if (features.pixrem !== false) {
-    features.pixrem = {
-      browsers: (
-        features.pixrem && features.pixrem.browsers
-          ? features.pixrem.browsers
-          : options.browsers
-      ),
-      ...(features.pixrem || {}),
-    }
+  // autoprefixer doesn't like an "undefined" value. Related to coffee ?
+  if (features.autoprefixer && features.autoprefixer.browsers === undefined) {
+    delete features.autoprefixer.browsers
   }
 
   const processor = postcss()

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,18 @@ const plugin = postcss.plugin("postcss-cssnext", (options) => {
     }
   }
 
+  // propagate browsers option to pixrem
+  if (features.pixrem !== false) {
+    features.pixrem = {
+      browsers: (
+        features.pixrem && features.pixrem.browsers
+          ? features.pixrem.browsers
+          : options.browsers
+      ),
+      ...(features.pixrem || {}),
+    }
+  }
+
   const processor = postcss()
 
   // features


### PR DESCRIPTION
This PR will enable `pixrem` to use cssnext's own browsers option instead of requiring one of his own.

Addresses #263 and #174 