### PR TITLE
add overflow-wrap fallback

### DIFF
--- a/docs/content/features.md
+++ b/docs/content/features.md
@@ -392,6 +392,20 @@ a::before {
 |
 [Plugin documentation](https://github.com/axa-ch/postcss-pseudoelements)
 
+## `overflow-wrap` property (`word-wrap` fallback)
+
+Converts `overflow-wrap` to `word-wrap` (many browser support only the old [word-wrap](http://caniuse.com/#feat=wordwrap) property).
+
+```css
+body {
+  overflow-wrap: break-word;
+}
+```
+
+[Specification](https://drafts.csswg.org/css-text-3/#propdef-word-wrap)
+|
+[Plugin documentation](https://github.com/MattDiMu/postcss-replace-overflow-wrap)
+
 ## @todo
 
 Any omissions of the CSS specifications (even in draft) that are subject to be

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -126,6 +126,12 @@ title: cssnext - Use tomorrow’s CSS syntax, today.
           (<code>:</code> fallback)
         </small>
       </li>
+      <li class="r-Grid-cell r-minS--1of2">
+        <a href="/features/#replace-overflow-wrap"><code>overflow-wrap</code> property</a>
+        <small class="cssnext-FeaturesList-small">
+          (<code>word-wrap</code> fallback)
+        </small>
+      </li>
     </ul>
     <small
       class="cssnext-FeaturesList-small"

--- a/docs/content/playground.html
+++ b/docs/content/playground.html
@@ -63,6 +63,11 @@ filter: blur(4px);
 filter: sepia(.8);
 }
 
+/* overflow-wrap fallback */
+body {
+overflow-wrap: break-word;  
+}
+
     </textarea>
   </div>
   <div class="cssnext-Playground-section cssnext-Playground-section--to">

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "postcss-nesting": "^2.0.5",
     "postcss-pseudo-class-any-link": "^1.0.0",
     "postcss-pseudoelements": "^3.0.0",
+    "postcss-replace-overflow-wrap": "^1.0.0",
     "postcss-selector-matches": "^2.0.0",
     "postcss-selector-not": "^2.0.0"
   },

--- a/src/__tests__/fixtures/features/replace-overflow-wrap.css
+++ b/src/__tests__/fixtures/features/replace-overflow-wrap.css
@@ -1,0 +1,3 @@
+body {
+  overflow-wrap: break-word;
+}

--- a/src/__tests__/fixtures/features/replace-overflow-wrap.expected.css
+++ b/src/__tests__/fixtures/features/replace-overflow-wrap.expected.css
@@ -1,0 +1,3 @@
+body {
+  word-wrap: break-word;
+}

--- a/src/features.js
+++ b/src/features.js
@@ -66,6 +66,9 @@ export default {
   // https://npmjs.com/package/postcss-color-rgba-fallback
   colorRgba: (options) => require("postcss-color-rgba-fallback")(options),
 
+  // https://www.npmjs.com/package/postcss-replace-overflow-wrap
+  replaceOverflowWrap: (options) => require("postcss-replace-overflow-wrap")(options),
+
   // https://npmjs.com/package/autoprefixer
   autoprefixer: (options) => require("autoprefixer")(options),
 }


### PR DESCRIPTION
I've recently created a postcss-plugin to create a fallback from overflow-wrap to word-wrap and i think, it might be useful in the cssnext plugin pack:

Specification: https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap
Plugin: https://www.npmjs.com/package/postcss-replace-overflow-wrap
Github-Repo: https://github.com/MattDiMu/postcss-replace-overflow-wrap
Browser Support (overflow-wrap vs word-wrap): http://caniuse.com/#feat=wordwrap

It's the first time, that I've ever contributed to cssnext, therefore I've simply worked through the Contributing.md guidelines and hopefully haven't forgotten anything.

Cheers
Matt