### PR TITLE
Add postcss-apply plugin

### DIFF
--- a/docs/content/features.md
+++ b/docs/content/features.md
@@ -18,7 +18,7 @@ depending on your browser scope) using
 **[autoprefixer](https://github.com/postcss/autoprefixer)**).
 
 
-## custom properties & `var()`
+## custom properties &amp; `var()`
 
 The current transformation for custom properties aims to provide a
 future-proof way of using a **limited subset (to top-level `:root` selector)**
@@ -41,6 +41,30 @@ might happen).
 [Specification](http://www.w3.org/TR/css-variables/)
 |
 [Plugin documentation](https://github.com/postcss/postcss-custom-properties)
+
+## custom properties set &amp; `@apply`
+
+Allows you to store a set of properties in a named variable, then reference them
+in other style rules.
+
+```css
+:root {
+  --danger-theme: {
+    color: white;
+    background-color: red;
+  };
+}
+
+.danger {
+  @apply --danger-theme;
+}
+```
+
+(The same DOM restrictions as the custom properties plugin apply).
+
+[Specification](https://tabatkins.github.io/specs/css-apply-rule)
+|
+[Plugin documentation](https://github.com/pascalduez/postcss-apply)
 
 ## reduced `calc()`
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -51,7 +51,10 @@ title: cssnext - Use tomorrow’s CSS syntax, today.
         <a href="/features/#automatic-vendor-prefixes">automatic vendor prefixes</a>
       </li>
       <li class="r-Grid-cell r-minS--1of2">
-        <a href="/features/#custom-properties-var">custom properties & <code>var()</code></a>
+        <a href="/features/#custom-properties-var">custom properties &amp; <code>var()</code></a>
+      </li>
+      <li class="r-Grid-cell r-minS--1of2">
+        <a href="/features/#custom-properties-set-apply">custom properties set &amp; <code>@apply</code></a>
       </li>
       <li class="r-Grid-cell r-minS--1of2">
         <a href="/features/#reduced-calc">reduced <code>calc()</code></a>

--- a/docs/content/playground.html
+++ b/docs/content/playground.html
@@ -16,6 +16,19 @@ scripts:
 --highlightColor: hwb(190, 35%, 20%);
 }
 
+/* custom properties set & @apply rule */
+:root {
+  --centered: {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  };
+}
+
+.centered {
+  @apply --centered;
+}
+
 /* custom media queries */
 @custom-media --viewport-medium (width <= 50rem);
 
@@ -65,7 +78,7 @@ filter: sepia(.8);
 
 /* overflow-wrap fallback */
 body {
-overflow-wrap: break-word;  
+overflow-wrap: break-word;
 }
 
     </textarea>

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "pixrem": "^3.0.0",
     "pleeease-filters": "^3.0.0",
     "postcss": "^5.0.4",
+    "postcss-apply": "^0.3.0",
     "postcss-calc": "^5.0.0",
     "postcss-color-function": "^2.0.0",
     "postcss-color-gray": "^3.0.0",

--- a/src/__tests__/fixtures/features/apply-rule.css
+++ b/src/__tests__/fixtures/features/apply-rule.css
@@ -1,0 +1,10 @@
+:root {
+  --foo-set: {
+    color: tomato;
+    content: 'foo';
+  };
+}
+
+.foo {
+  @apply --foo-set;
+}

--- a/src/__tests__/fixtures/features/apply-rule.expected.css
+++ b/src/__tests__/fixtures/features/apply-rule.expected.css
@@ -1,0 +1,4 @@
+.foo {
+  color: tomato;
+  content: 'foo';
+}

--- a/src/features.js
+++ b/src/features.js
@@ -9,6 +9,9 @@ export default {
    // https://npmjs.com/package/postcss-custom-properties
   customProperties: (options) => require("postcss-custom-properties")(options),
 
+  // https://npmjs.com/package/postcss-apply
+  applyRule: (options) => require("postcss-apply")(options),
+
   // https://npmjs.com/package/postcss-calc
   calc: (options) => require("postcss-calc")(options),
 


### PR DESCRIPTION
Hi,

I'm not 100% sure about the plugin order, since it's supposed to be really similar with the custom properties one, I placed it next. 
So  basically all other transformations will happen on the applied rules, instead of the stored rules. Maybe in case of huge sets usage it could have an impact? 

I added [tests locally](https://github.com/pascalduez/postcss-apply/blob/master/test/integration.test.js) to the plugin to ensure it doesn't interfere with the custom properties one.

Refs #203 


