### PR TITLE
Remove contributing docs about tests/cases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,6 @@ module directly in console._
 ### Add a feature
 
 1. Add test files (input + expected output) in [`src/__tests__/fixtures/features`](src/__tests__/features)
-- If the feature can affect some others, update [`src/__tests__/fixtures/cases/example.css`](src/__tests__/cases/example.css) to test integration with other features
 
 - Choose a pretty simple and clear name (that match the specs), if you are not sure, ask using an issue.
 - Add the feature in :


### PR DESCRIPTION
Hi,

the `CONTRIBUTING` docs states for `src/__tests__/fixtures/cases/example.css` but this file no longer exist, removed in [eef525](https://github.com/MoOx/postcss-cssnext/commit/eef525a9fd086801224d029d572d3ca7982705c2). So I guess it's safe to prune?

