### PR TITLE
Disable colorHexAlpha for now

### DIFF
--- a/src/features-activation-map.js
+++ b/src/features-activation-map.js
@@ -20,7 +20,7 @@ export default {
   // colorHwb: [ null ],
   // colorRgb: [ null ],
   // colorGray: [ null ],
-  colorHexAlpha: [ "css-rrggbbaa" ],
+  // colorHexAlpha: [ "css-rrggbbaa" ],
   // colorFunction:[ null],
   // fontVariant: [ null ],
   // @todo can be done using a callback, this is only used for Firefox < 35


### PR DESCRIPTION
It's giving errors, see #357.

I don't really know why it's giving errors, so I can't fix it at the source, but it might be a good idea to at least release a version that does not produce error in the mean time :)