### PR TITLE
Make sure the installed caniuse-db is up-to-date

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "postcss-selector-matches": "^2.0.0",
     "postcss-selector-not": "^2.0.0"
   },
+  "peerDependencies": {
+    "caniuse-db": "^1.0.30000636"
+  },
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.2",


### PR DESCRIPTION
We're checking for data on `css-rrggbbaa` usage, which was only added in recent updates to the db. If users have previously installed older versions of caniuse-db (not unlikely), then that would still be installed and there'd be an error because the data on `css-rrggbbaa` wasn't available yet.

I think specifying this as a `peerDependency` should force package managers to at least have a version of caniuse-db that includes the required data.

Fixes #357.