### PR TITLE
Remember to export in usage examples

### DIFF
--- a/usage/index.html
+++ b/usage/index.html
@@ -199,7 +199,7 @@ find a <code>browserslist</code> config file or use its default value.</em></p>
 <span class="hljs-keyword">var</span> postcss = <span class="hljs-built_in">require</span>(<span class="hljs-string">"postcss"</span>)
 <span class="hljs-keyword">var</span> cssnext = <span class="hljs-built_in">require</span>(<span class="hljs-string">"postcss-cssnext"</span>)
 
-postcss([
+module.exports = postcss([
   cssnext({
     features: {
       customProperties: <span class="hljs-literal">false</span>
@@ -213,7 +213,7 @@ To pass options to a feature, you can just pass an object to the feature:</p>
 <span class="hljs-keyword">var</span> postcss = <span class="hljs-built_in">require</span>(<span class="hljs-string">"postcss"</span>)
 <span class="hljs-keyword">var</span> cssnext = <span class="hljs-built_in">require</span>(<span class="hljs-string">"postcss-cssnext"</span>)
 
-postcss([
+module.exports = postcss([
   cssnext({
     features: {
       customProperties: {


### PR DESCRIPTION
I was just setting up `postcss-cssnext` based on the [usage examples](http://cssnext.io/usage/) and ran into the [issue that nothing was exported](http://stackoverflow.com/a/43334198/770127). Makes sense right? This updates the examples to export to `module.exports`