### PR TITLE
Add .editorconfig to gh-pages branch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Uses the same [.editorconfig](https://github.com/MoOx/postcss-cssnext/blob/master/.editorconfig) as master to help prevent whitespace diffs in PRs