### PR TITLE
Ensure a version of caniuse-db that includes css-image-set

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "postcss-selector-not": "^2.0.0"
   },
   "peerDependencies": {
-    "caniuse-db": "^1.0.30000652"
+    "caniuse-db": "^1.0.30000670"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
postcss-cssnext added a polyfill for `css-image-set`. However, if the version one has installed of caniuse-db is too old (as often happens if you installed postcss-cssnext earlier and are upgrading - since peerDependencies are not upgraded if they still match the specified version range), the check for whether it is supported will fail.