### PR TITLE
Use PostCSS 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chalk": "^1.1.1",
     "pixrem": "^3.0.0",
     "pleeease-filters": "^3.0.0",
-    "postcss": "^5.0.4",
+    "postcss": "^6.0.1",
     "postcss-apply": "^0.3.0",
     "postcss-attribute-case-insensitive": "^1.0.1",
     "postcss-calc": "^5.0.0",

--- a/src/__tests__/fixtures/features/apply-rule.expected.css
+++ b/src/__tests__/fixtures/features/apply-rule.expected.css
@@ -1,4 +1,4 @@
 .foo {
-  color: tomato;
-  content: 'foo';
+    color: tomato;
+    content: 'foo';
 }

--- a/src/__tests__/fixtures/features/image-set.expected.css
+++ b/src/__tests__/fixtures/features/image-set.expected.css
@@ -1,13 +1,9 @@
 .image {
   background-image: url(img/test.png);
+}@media (min-resolution: 144dpi) {.image {
+  background-image: url(img/test-2x.png);
 }
-@media (min-resolution: 144dpi) {
-  .image {
-    background-image: url(img/test-2x.png);
-  }
+}@media (min-resolution: 600dpi) {.image {
+  background-image: url(my-img-print.png);
 }
-@media (min-resolution: 600dpi) {
-  .image {
-    background-image: url(my-img-print.png);
-  }
 }

--- a/src/__tests__/fixtures/features/nesting.expected.css
+++ b/src/__tests__/fixtures/features/nesting.expected.css
@@ -2,5 +2,5 @@
   color: red
 }
 .foo .bar {
-  color: white
+    color: white
 }

--- a/src/__tests__/fixtures/regression.expected.css
+++ b/src/__tests__/fixtures/regression.expected.css
@@ -2,6 +2,5 @@
 }
 
 .button i {
-
     color: black
 }

--- a/src/__tests__/option.browsers.js
+++ b/src/__tests__/option.browsers.js
@@ -13,7 +13,7 @@ tape("cssnext browsers option", function(t) {
   )
 
   const customPropsInput = ":root{--foo:bar}baz{qux:var(--foo)}"
-  const customPropsOutput = "baz{qux: bar}"
+  const customPropsOutput = "baz{qux:bar}"
 
   // fx 30 doesn't handle custom prop
   t.equal(


### PR DESCRIPTION
This updates dependencies to use PostCSS 6. It also updates tests for whitespacing, which PostCSS 6 captures more accurately.

I’m sure we could do more, and we don’t need to cut a release with just this change, but why not start with the basics?