### PR TITLE
chore(package): update postcss-font-family-system-ui to version 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "postcss-custom-media": "^6.0.0",
     "postcss-custom-properties": "^6.1.0",
     "postcss-custom-selectors": "^4.0.1",
-    "postcss-font-family-system-ui": "^2.0.1",
+    "postcss-font-family-system-ui": "^3.0.0",
     "postcss-font-variant": "^3.0.0",
     "postcss-image-set-polyfill": "^0.3.5",
     "postcss-initial": "^2.0.0",

--- a/src/__tests__/fixtures/features/font-family-system-ui.expected.css
+++ b/src/__tests__/fixtures/features/font-family-system-ui.expected.css
@@ -1,9 +1,9 @@
 selector {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Droid Sans, Helvetica Neue, sans-serif;
 }
 
 selector {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, Helvetica Neue, sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Droid Sans, Helvetica Neue, sans-serif;
 }
 
 selector {
@@ -11,11 +11,11 @@ selector {
 }
 
 selector {
-  font: italic bold 12px/30px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font: italic bold 12px/30px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Droid Sans, Helvetica Neue, sans-serif;
 }
 
 selector {
-  font: italic bold 12px/30px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, Helvetica Neue, sans-serif;
+  font: italic bold 12px/30px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Droid Sans, Helvetica Neue, sans-serif;
 }
 
 selector {


### PR DESCRIPTION
The version 3.0 is ground-up rewritten and complies to https://github.com/postcss/postcss-plugin-boilerplate.

See https://github.com/JLHwung/postcss-font-family-system-ui/blob/3.0.0/CHANGELOG.md for the changelog.