### PR TITLE
Update postcss-cli usage example

### DIFF
--- a/docs/content/postcss.md
+++ b/docs/content/postcss.md
@@ -77,9 +77,10 @@ and previous default cssnext behavior.
 $ npm install postcss-cli --save-dev
 ```
 
-Here is an example of the json config you might use with something like
+Here is an example of the JS config you might use with something like
 ``$ postcss input.css -o output.css``.
 
+**postcss.config.js**
 ```js
 module.exports = {
   plugins: [

--- a/docs/content/postcss.md
+++ b/docs/content/postcss.md
@@ -78,20 +78,19 @@ $ npm install postcss-cli --save-dev
 ```
 
 Here is an example of the json config you might use with something like
-``$ postcss -c postcss.config.json``.
+``$ postcss input.css -o output.css``.
 
 ```js
-{
-  "use": [
-    "postcss-import",
-    "postcss-url",
-    "postcss-cssnext",
+module.exports = {
+  plugins: [
+    require('postcss-import'),
+    require('postcss-url'),
+    require('postcss-cssnext'),
     // add your "plugins" here
     // ...
     // and if you want to compress
-    // "cssnano",
-    "postcss-browser-reporter",
-    "postcss-reporter"
+    // require('cssnano'),
+    require('postcss-browser-reporter')
   ]
 }
 ```


### PR DESCRIPTION
postcss-cli maintainer here. In later versions, we've changed the config file format significantly. I've updated the usage examples to reflect this. I've also removed `postcss-reporter` from the example, since postcss-cli includes it by default anyhow.