### PR TITLE
move `postcss-apply` above `postcss-custom-properties` in feature order

### DIFF
--- a/src/features.js
+++ b/src/features.js
@@ -7,11 +7,11 @@ export default {
    * order is important
    * ******************
    */
-  // https://npmjs.com/package/postcss-custom-properties
-  customProperties: options => require("postcss-custom-properties")(options),
-
   // https://npmjs.com/package/postcss-apply
   applyRule: options => require("postcss-apply")(options),
+
+  // https://npmjs.com/package/postcss-custom-properties
+  customProperties: options => require("postcss-custom-properties")(options),
 
   // https://npmjs.com/package/postcss-calc
   calc: options => require("postcss-calc")(options),


### PR DESCRIPTION
I tried to use CSS vars in my `postcss-apply` [options#set](https://github.com/pascalduez/postcss-apply#sets) but it did not work unless I moved `postcss-apply` above `postcss-custom-properties` in feature.js.

[RunKit example](https://runkit.com/albertstill/5a98b5e8108a92001272a5f4)

```javascript
require("postcss-cssnext")({
  features: {
    customProperties: {
      variables: {
        "h1-mobile-font-size": "36px"
      },
      applyRule: {
        sets: {
          "font-h1": {
            fontSize: "var(--h1-mobile-font-size)"
          }
        }
      }
    }
  }
});

```

Is this an issue with cssnext or the concerned packages? Not sure if this causes problems elsewhere?

Appreciate that `postcss-apply` is being depreciated.