### PR TITLE
chore: remove Node.js 4 (EOL), add Node.js 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 
 language: node_js
 node_js:
+  - 10
   - 8
   - 6
-  - 4
 
 script:
   - npm run test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@
 
 environment:
   matrix:
+    - nodejs_version: 10
     - nodejs_version: 8
     - nodejs_version: 6
-    - nodejs_version: 4
 
 version: "{build}"
 build: off


### PR DESCRIPTION
Node.js 4 is EOL and many dependencies do not support it anymore (see the failing appveyor tests on Windows).