### PR TITLE
Separate URL and period for automatic link

### DIFF
--- a/src/warn-for-deprecations.js
+++ b/src/warn-for-deprecations.js
@@ -23,7 +23,7 @@ const warnForDeprecations = postcss.plugin(
                   "spec is yet considered deprecated and alternative solutions are being " +
                   "discussed. \n"
               ) +
-              "Read more about the reason here https://github.com/pascalduez/postcss-apply."
+              "Read more about the reason here https://github.com/pascalduez/postcss-apply ."
           );
         }
       });


### PR DESCRIPTION
- Some terminal software has automatic linking feature that may make a link that contains trailing period and it may make missing.
- This commit add trailing space to the URL.
- Close #462